### PR TITLE
Prevent having GitHub force the action to run on `node20`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install GH CLI
         uses: alexnorell/install-gh-cli-action@main
       - name: git describe
         id: ghd
-        uses: proudust/gh-describe@v1
+        uses: proudust/gh-describe@v2.0.0
   test-latest:
     name: Test Action Latest (Linux)
     permissions:
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install GH CLI
         uses: alexnorell/install-gh-cli-action@main
         with:
           cli-release: latest
       - name: git describe
         id: ghd
-        uses: proudust/gh-describe@v1
+        uses: proudust/gh-describe@v2.0.0
   test-specific:
     name: Test Action Specific Version (Linux)
     permissions:
@@ -46,11 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install GH CLI
         uses: alexnorell/install-gh-cli-action@main
         with:
-          cli-release: v2.36.0
+          cli-release: v2.57.0
       - name: git describe
         id: ghd
-        uses: proudust/gh-describe@v1
+        uses: proudust/gh-describe@v2.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install GH CLI
-        uses: alexnorell/install-gh-cli-action@main
+        uses: ./
       - name: git describe
         id: ghd
         uses: proudust/gh-describe@v2.0.0
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install GH CLI
-        uses: alexnorell/install-gh-cli-action@main
+        uses: ./
         with:
           cli-release: latest
       - name: git describe
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install GH CLI
-        uses: alexnorell/install-gh-cli-action@main
+        uses: ./
         with:
           cli-release: v2.57.0
       - name: git describe

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: 'linux'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'arrow-down'


### PR DESCRIPTION
## Motivation

Initially opening as Draft in order to check CI results and potentially fix any issues from it.

## Further considerations

It'd be much appreciated if you would generate the release and tag this on accepting the pull request.